### PR TITLE
fix: use require.resolve

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -73,16 +73,15 @@ exports.main = function (argv) {
     // get uglified *.min.js
     console.log(`creating ${name}.min.js...`);
     process.argv = [ 'bala', 'bala', path.join(output, `${name}.js`), '--output', path.join(output, `${name}.min.js`), '--compress', '--mangle' ];
-    let uglifyjsPath = path.join(__dirname, '..', 'node_modules', 'uglify-js');
+    let uglifyjsPath = require.resolve('uglify-js');
     // make sure it could be exected everty time from tests
     try {
         // cnpm use symlinks
         uglifyjsPath = path.join(__dirname, '..', 'node_modules', fs.readlinkSync(uglifyjsPath));
     } catch (e) {}
 
-    var uglifyjsBin = path.join(uglifyjsPath, 'bin', 'uglifyjs');
-    delete require.cache[uglifyjsBin];
-    require(uglifyjsBin);
+    delete require.cache[uglifyjsPath];
+    require(uglifyjsPath);
 
     console.log('done');
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@types/node": "^15.3.0",
+    "typescript": "^4.7.4",
     "tape": "^5.2.2"
   }
 }


### PR DESCRIPTION
Addresses a path assumption that the node require logic
can solve. This also adds typescript as a dev dependency
since `npm test` doesn't work otherwise.

Fixes #7 